### PR TITLE
Use Workiva docker credentials in Service Accounts

### DIFF
--- a/base/cadvisor/cadvisor.ServiceAccount.yaml
+++ b/base/cadvisor/cadvisor.ServiceAccount.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
+imagePullSecrets:
+- name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:

--- a/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: docker-registry
+- name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:

--- a/base/grafana/grafana.ServiceAccount.yaml
+++ b/base/grafana/grafana.ServiceAccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: docker-registry
+- name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:

--- a/base/prometheus/prometheus.ServiceAccount.yaml
+++ b/base/prometheus/prometheus.ServiceAccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: docker-registry
+- name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:


### PR DESCRIPTION
Use Workiva's Docker credentials when not using a default Service Account. These credentials will be available in all Workiva K8s clusters.

Without the credentials configured, it will default to accessing Docker Hub anonymously when pulling images, which is prone to being rate limited. 

@trentgrover-wf 