### PR TITLE
Disable cadvisor

### DIFF
--- a/base/cadvisor/cadvisor.ClusterRole.yaml
+++ b/base/cadvisor/cadvisor.ClusterRole.yaml
@@ -4,7 +4,8 @@ metadata:
   labels:
     app: cadvisor
     category: rbac
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor

--- a/base/cadvisor/cadvisor.ClusterRoleBinding.yaml
+++ b/base/cadvisor/cadvisor.ClusterRoleBinding.yaml
@@ -4,7 +4,8 @@ metadata:
   labels:
     app: cadvisor
     category: rbac
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor

--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -5,7 +5,8 @@ metadata:
     description: DaemonSet to ensure all nodes run a cAdvisor pod.
     seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
   labels:
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor
@@ -20,7 +21,8 @@ spec:
         prometheus.io/port: "48080"
         sourcegraph.prometheus/scrape: "true"
       labels:
-        deploy: sourcegraph
+        # WORKIVA CHANGE: disable cadvisor
+        # deploy: sourcegraph
         app: cadvisor
     spec:
       serviceAccountName: cadvisor

--- a/base/cadvisor/cadvisor.PodSecurityPolicy.yaml
+++ b/base/cadvisor/cadvisor.PodSecurityPolicy.yaml
@@ -3,7 +3,8 @@ kind: PodSecurityPolicy
 metadata:
   labels:
     app: cadvisor
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor

--- a/base/cadvisor/cadvisor.ServiceAccount.yaml
+++ b/base/cadvisor/cadvisor.ServiceAccount.yaml
@@ -1,12 +1,14 @@
 apiVersion: v1
 imagePullSecrets:
+# WORKIVA CHANGE
 - name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:
     app: cadvisor
     category: rbac
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor


### PR DESCRIPTION
cadvisor is a daemonset and we don't want to have extra daemonsets in the cluster unless necessary. I've manually deleted it from wk-dev, but this PR is to prevent it from being recreated next time sourcegraph is deployed.

The deploy script runs `kubectl apply` with `-l deploy=sourcegraph`: https://github.com/trentgrover-wf/deploy-sourcegraph/blob/b2101646c6c8d27b0615bcdd88c2d38f21cc731e/kubectl-apply-all.sh#L15

Removing that label from resources prevents them from being created.

@trentgrover-wf 