### PR TITLE
Remove ephemeral storage request from prometheus

### DIFF
--- a/base/cadvisor/cadvisor.ClusterRole.yaml
+++ b/base/cadvisor/cadvisor.ClusterRole.yaml
@@ -4,7 +4,8 @@ metadata:
   labels:
     app: cadvisor
     category: rbac
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor

--- a/base/cadvisor/cadvisor.ClusterRoleBinding.yaml
+++ b/base/cadvisor/cadvisor.ClusterRoleBinding.yaml
@@ -4,7 +4,8 @@ metadata:
   labels:
     app: cadvisor
     category: rbac
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor

--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -5,7 +5,8 @@ metadata:
     description: DaemonSet to ensure all nodes run a cAdvisor pod.
     seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
   labels:
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor
@@ -20,7 +21,8 @@ spec:
         prometheus.io/port: "48080"
         sourcegraph.prometheus/scrape: "true"
       labels:
-        deploy: sourcegraph
+        # WORKIVA CHANGE: disable cadvisor
+        # deploy: sourcegraph
         app: cadvisor
     spec:
       serviceAccountName: cadvisor

--- a/base/cadvisor/cadvisor.DaemonSet.yaml
+++ b/base/cadvisor/cadvisor.DaemonSet.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cadvisor
       containers:
       - name: cadvisor
-        image: index.docker.io/sourcegraph/cadvisor:insiders@sha256:a99cf5d8ff6337041b7cd420c6bccd048a65ee8266876de5f77a3b2670693244
+        image: index.docker.io/sourcegraph/cadvisor:3.24.0@sha256:7c85e692ea50b5b73db9163c9eb71d547710dd8a5f35e52080368d44111ad5bc
         args:
         # Kubernetes-specific flags below (other flags are baked into the Docker image)
         #

--- a/base/cadvisor/cadvisor.PodSecurityPolicy.yaml
+++ b/base/cadvisor/cadvisor.PodSecurityPolicy.yaml
@@ -3,7 +3,8 @@ kind: PodSecurityPolicy
 metadata:
   labels:
     app: cadvisor
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor

--- a/base/cadvisor/cadvisor.ServiceAccount.yaml
+++ b/base/cadvisor/cadvisor.ServiceAccount.yaml
@@ -1,12 +1,14 @@
 apiVersion: v1
 imagePullSecrets:
+# WORKIVA CHANGE
 - name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:
     app: cadvisor
     category: rbac
-    deploy: sourcegraph
+    # WORKIVA CHANGE: disable cadvisor
+    # deploy: sourcegraph
     sourcegraph-resource-requires: cluster-admin
     app.kubernetes.io/component: cadvisor
   name: cadvisor

--- a/base/cadvisor/cadvisor.ServiceAccount.yaml
+++ b/base/cadvisor/cadvisor.ServiceAccount.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
+imagePullSecrets:
+- name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:

--- a/base/codeintel-db/codeintel-db.Deployment.yaml
+++ b/base/codeintel-db/codeintel-db.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
       - name: correct-data-dir-permissions
-        image: sourcegraph/alpine:3.10@sha256:4d05cd5669726fc38823e92320659a6d1ef7879e62268adec5df658a0bacf65c
+        image: sourcegraph/alpine:3.12@sha256:133a0a767b836cf86a011101995641cf1b5cbefb3dd212d78d7be145adde636d
         command: ["sh", "-c", "if [ -d /data/pgdata-11 ]; then chmod 750 /data/pgdata-11; fi"]
         volumeMounts:
         - mountPath: /data
@@ -34,7 +34,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/codeintel-db:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/codeintel-db:3.24.0@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: CODEINTEL_PGUSER
           value: sg
         - name: SRC_GIT_SERVERS
-          value: gitserver-0.gitserver:3178
+          value: gitserver-0.gitserver:3178 gitserver-1.gitserver:3178 gitserver-2.gitserver:3178
         # POD_NAME is used by CACHE_DIR
         - name: POD_NAME
           valueFrom:
@@ -93,9 +93,11 @@ spec:
           limits:
             cpu: "2"
             memory: 4G
+            ephemeral-storage: "10Gi"
           requests:
             cpu: "2"
             memory: 2G
+            ephemeral-storage: "1Gi"
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd

--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: index.docker.io/sourcegraph/frontend:insiders@sha256:2af33e3786bfe310f1007a3ecdeb832b1857636780e7e1d04089e162df1dc9d4
+        image: index.docker.io/sourcegraph/frontend:3.24.0@sha256:0cd42a1922384266b0bf900443c9b32f56ca1c67dc0ce6e655cf0d4e2599ef7d
         args:
         - serve
         env:
@@ -100,7 +100,7 @@ spec:
         - mountPath: /mnt/cache
           name: cache-ssd
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:01b0798f278b80b7b312caf53792a0207ca958fd88487e7ec6857b6b88694caf
+        image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/frontend/sourcegraph-frontend.Ingress.yaml
+++ b/base/frontend/sourcegraph-frontend.Ingress.yaml
@@ -14,13 +14,14 @@ metadata:
     sourcegraph-resource-requires: no-cluster-admin
     app.kubernetes.io/component: frontend
   name: sourcegraph-frontend
+  namespace: workiva
 spec:
   # See the customization guide (../../../docs/configure.md) for information
   # about configuring TLS
-  # tls:
-  # - hosts:
-  #   - sourcegraph.example.com
-  #   secretName: sourcegraph-tls
+  tls:
+  - hosts:
+    - sourcegraph.wk-dev.wdesk.org
+    secretName: default-ingress-cert
   rules:
   - http:
       paths:
@@ -30,4 +31,4 @@ spec:
           servicePort: 30080
     # If you're using TLS/SSL, uncomment the following line and replace 'sourcegraph.example.com' with the real
     # domain that you want to use for your Sourcegraph instance.
-    # host: sourcegraph.example.com
+    host: sourcegraph.wk-dev.wdesk.org

--- a/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
+++ b/base/frontend/sourcegraph-frontend.ServiceAccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: docker-registry
+- name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:

--- a/base/github-proxy/github-proxy.Deployment.yaml
+++ b/base/github-proxy/github-proxy.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/github-proxy:insiders@sha256:7f2d5f0c7e5411f7890c7d45b8630aa9464dde1a3dd722dde3c01617f3aaae1e
+        image: index.docker.io/sourcegraph/github-proxy:3.24.0@sha256:ee5d7156b281812b60e176c41f944692be61f053a1dfd545ecf164f5e58709ff
         terminationMessagePolicy: FallbackToLogsOnError
         name: github-proxy
         ports:
@@ -41,7 +41,7 @@ spec:
           requests:
             cpu: 100m
             memory: 250M
-      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:01b0798f278b80b7b312caf53792a0207ca958fd88487e7ec6857b6b88694caf
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: gitserver
   name: gitserver
 spec:
-  replicas: 1
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -43,7 +43,7 @@ spec:
             cpu: "4"
             memory: 8G
           requests:
-            cpu: "4" 
+            cpu: "4"
             memory: 8G
         volumeMounts:
         - mountPath: /data/repos

--- a/base/gitserver/gitserver.StatefulSet.yaml
+++ b/base/gitserver/gitserver.StatefulSet.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - run
         env:
-        image: index.docker.io/sourcegraph/gitserver:insiders@sha256:193d7e8d473318fec402d9cc78c38546f70ce88d75103be5fb9912a9eb628fee
+        image: index.docker.io/sourcegraph/gitserver:3.24.0@sha256:aaffd21d18b791c73032e916c2bf69ecf51a3a97608ab748408889d5b192dfac
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 5
@@ -53,7 +53,7 @@ spec:
         # - mountPath: /root/.ssh
         #   name: ssh
       - name: jaeger-agent
-        image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:01b0798f278b80b7b312caf53792a0207ca958fd88487e7ec6857b6b88694caf
+        image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
         env:
           - name: POD_NAME
             valueFrom:

--- a/base/grafana/grafana.ServiceAccount.yaml
+++ b/base/grafana/grafana.ServiceAccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: docker-registry
+- name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:

--- a/base/grafana/grafana.StatefulSet.yaml
+++ b/base/grafana/grafana.StatefulSet.yaml
@@ -24,7 +24,7 @@ spec:
         deploy: sourcegraph
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/grafana:insiders@sha256:b2dc3e50ebeed6420ec78b159d7d0d3373ca51faa3dbc8a929ad1ffa7c521f31
+      - image: index.docker.io/sourcegraph/grafana:3.24.0@sha256:32b35cd39f13149ea2e7ca192c5ee97400b06aa6f7b5664b4cd79797d9d40417
         terminationMessagePolicy: FallbackToLogsOnError
         name: grafana
         ports:

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: indexed-search
   name: indexed-search
 spec:
-  replicas: 1
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/base/indexed-search/indexed-search.StatefulSet.yaml
+++ b/base/indexed-search/indexed-search.StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/indexed-searcher:insiders@sha256:76d7e8a7453caed03412064d2f8e40dd49b9df958edd846e5a91c514b840803e
+        image: index.docker.io/sourcegraph/indexed-searcher:3.24.0@sha256:76d7e8a7453caed03412064d2f8e40dd49b9df958edd846e5a91c514b840803e
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-webserver
         ports:
@@ -48,7 +48,7 @@ spec:
         - mountPath: /data
           name: data
       - env:
-        image: index.docker.io/sourcegraph/search-indexer:insiders@sha256:89fa7d5eac6f9f3e8893a482650dffcea4d22be993328427679af7e3ddd08e10
+        image: index.docker.io/sourcegraph/search-indexer:3.24.0@sha256:89fa7d5eac6f9f3e8893a482650dffcea4d22be993328427679af7e3ddd08e10
         terminationMessagePolicy: FallbackToLogsOnError
         name: zoekt-indexserver
         ports:

--- a/base/jaeger/jaeger.Deployment.yaml
+++ b/base/jaeger/jaeger.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
         prometheus.io/port: "16686"
     spec:
         containers:
-          - image: index.docker.io/sourcegraph/jaeger-all-in-one:insiders@sha256:83076ecafbc5002c8df71cc95c104d9705b27f5deba981229a0091842e28415d
+          - image: index.docker.io/sourcegraph/jaeger-all-in-one:3.24.0@sha256:64777c4affa429cbed6237f5055694dc1071155e350cfa4d10c35d8078d4da32
             name: jaeger
             args: ["--memory.max-traces=20000"]
             ports:

--- a/base/minio/minio.Deployment.yaml
+++ b/base/minio/minio.Deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: AKIAIOSFODNN7EXAMPLE
         - name: MINIO_SECRET_KEY
           value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-        image: index.docker.io/sourcegraph/minio:insiders@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
+        image: index.docker.io/sourcegraph/minio:3.24.0@sha256:3d7a0147396ea799284ba707765d477797518425682c9aa65faa5883a63fac4f
         args: ['minio', 'server', '/data']
         terminationMessagePolicy: FallbackToLogsOnError
         name: minio

--- a/base/pgsql/pgsql.Deployment.yaml
+++ b/base/pgsql/pgsql.Deployment.yaml
@@ -35,7 +35,7 @@ spec:
           runAsUser: 0
       containers:
       - env:
-        image: index.docker.io/sourcegraph/postgres-11.4:insiders@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
+        image: index.docker.io/sourcegraph/postgres-11.4:3.24.0@sha256:a55fea6638d478c2368c227d06a1a2b7a2056b693967628427d41c92d9209e97
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
@@ -67,7 +67,7 @@ spec:
           value: postgres://sg:@localhost:5432/?sslmode=disable
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /config/queries.yaml
-        image: sourcegraph/postgres_exporter:insiders@sha256:ac8ef017099276edef5df78fba63d633e68bd881fa56882074f4710e09ebe1ed
+        image: sourcegraph/postgres_exporter:3.24.0@sha256:793ddb0ba309ee1b52e116e6eb7498f0ca4e4b2ee885673ee7cf255c15fdadeb
         terminationMessagePolicy: FallbackToLogsOnError
         name: pgsql-exporter
         resources:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:insiders@sha256:6542a7ddb8d446a99bba1f56d595ad89e97732484060062929826705c1ae9397
+        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.24.0@sha256:7bb843018e52144a6cdeaa88c888df45aea6ed3b558b6cd991a2b3884e0fe9b1
         terminationMessagePolicy: FallbackToLogsOnError
         name: precise-code-intel-worker
         livenessProbe:

--- a/base/prometheus/prometheus.ClusterRoleBinding.yaml
+++ b/base/prometheus/prometheus.ClusterRoleBinding.yaml
@@ -14,3 +14,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
+  # value of namespace needs to match namespace value in base/prometheus/prometheus.ServiceAccount.yaml
+  namespace: workiva

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -61,13 +61,14 @@ spec:
           requests:
             cpu: 500m
             memory: 6G
+            ephemeral-storage: "10Gi"
       securityContext:
-        runAsUser: 0
+        runAsUser: 100
+        runAsGroup: 100
       serviceAccountName: prometheus
       volumes:
       - name: data
-        persistentVolumeClaim:
-          claimName: prometheus
+        emptyDir: {}
       - configMap:
           defaultMode: 0777
           name: prometheus

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -61,7 +61,8 @@ spec:
           requests:
             cpu: 500m
             memory: 6G
-            ephemeral-storage: "10Gi"
+            # WORKIVA CHANGE: Remove storage request
+            # ephemeral-storage: "10Gi"
       securityContext:
         runAsUser: 100
         runAsGroup: 100

--- a/base/prometheus/prometheus.Deployment.yaml
+++ b/base/prometheus/prometheus.Deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app: prometheus
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/prometheus:insiders@sha256:00fb1a5d854b3d7cbc432012ef3b7203bc5563f01b5c10bc01e364854ff3ad75
+      - image: index.docker.io/sourcegraph/prometheus:3.24.0@sha256:3ea1f8646f9b29143436dd1f4932ed106647388247f2ba7ad9956e97c3c05312
         terminationMessagePolicy: FallbackToLogsOnError
         name: prometheus
         readinessProbe:

--- a/base/prometheus/prometheus.ServiceAccount.yaml
+++ b/base/prometheus/prometheus.ServiceAccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: docker-registry
+- name: drydockcreds
 kind: ServiceAccount
 metadata:
   labels:

--- a/base/query-runner/query-runner.Deployment.yaml
+++ b/base/query-runner/query-runner.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/query-runner:insiders@sha256:7b1ebac6f7b2743476a60f5a99aa784563e801607393ae84c8c875c2802164f2
+        image: index.docker.io/sourcegraph/query-runner:3.24.0@sha256:30b3c14098447148270bd0ff4552a0a7a76c07e6f72fc809a829d6d54426544a
         terminationMessagePolicy: FallbackToLogsOnError
         name: query-runner
         ports:
@@ -41,7 +41,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1G
-      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:01b0798f278b80b7b312caf53792a0207ca958fd88487e7ec6857b6b88694caf
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/redis/redis-cache.Deployment.yaml
+++ b/base/redis/redis-cache.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-cache:insiders@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
+        image: index.docker.io/sourcegraph/redis-cache:3.24.0@sha256:7820219195ab3e8fdae5875cd690fed1b2a01fd1063bd94210c0e9d529c38e56
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/redis/redis-store.Deployment.yaml
+++ b/base/redis/redis-store.Deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/redis-store:insiders@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
+        image: index.docker.io/sourcegraph/redis-store:3.24.0@sha256:e8467a8279832207559bdfbc4a89b68916ecd5b44ab5cf7620c995461c005168
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           initialDelaySeconds: 30

--- a/base/repo-updater/repo-updater.Deployment.yaml
+++ b/base/repo-updater/repo-updater.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
         app: repo-updater
     spec:
       containers:
-      - image: index.docker.io/sourcegraph/repo-updater:insiders@sha256:fcf1019c15f918e673b7de44e24fd54ce0b80344edaf725ae67c1a7e70ffb47e
+      - image: index.docker.io/sourcegraph/repo-updater:3.24.0@sha256:4b4303984ebff22af65d848108a334d1f2de7fafae7ccb39a3f24c2c3b6185d2
         env:
         terminationMessagePolicy: FallbackToLogsOnError
         name: repo-updater
@@ -52,7 +52,7 @@ spec:
           requests:
             cpu: "1"
             memory: 500Mi
-      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:01b0798f278b80b7b312caf53792a0207ca958fd88487e7ec6857b6b88694caf
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   name: searcher
 spec:
   minReadySeconds: 10
-  replicas: 1
+  replicas: 10
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/base/searcher/searcher.Deployment.yaml
+++ b/base/searcher/searcher.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/searcher:insiders@sha256:8acc736279e51ed49aba6f7c40a1628c2a626f27818c520331f4135dcbc5f2b3
+        image: index.docker.io/sourcegraph/searcher:3.24.0@sha256:3f315c62a9081e57e95571085bbc5f3e25a05edfe1b63d275f22d11b5db37e73
         terminationMessagePolicy: FallbackToLogsOnError
         name: searcher
         ports:
@@ -62,7 +62,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:01b0798f278b80b7b312caf53792a0207ca958fd88487e7ec6857b6b88694caf
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/sourcegraph.StorageClass.yaml
+++ b/base/sourcegraph.StorageClass.yaml
@@ -1,0 +1,10 @@
+# base/sourcegraph.StorageClass.yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: sourcegraph
+  labels:
+    deploy: sourcegraph
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2 # This configures SSDs (recommended).

--- a/base/symbols/symbols.Deployment.yaml
+++ b/base/symbols/symbols.Deployment.yaml
@@ -36,7 +36,7 @@ spec:
               fieldPath: metadata.name
         - name: CACHE_DIR
           value: /mnt/cache/$(POD_NAME)
-        image: index.docker.io/sourcegraph/symbols:insiders@sha256:596ef070dc87e6b1c9cb15739178228b364032e8278916a3770dc6fda7ac0387
+        image: index.docker.io/sourcegraph/symbols:3.24.0@sha256:589a6a025a9c94ee8165ed43977e7e3e54c9631414c53a35d4927e5ad7774bdd
         terminationMessagePolicy: FallbackToLogsOnError
         name: symbols
         livenessProbe:
@@ -68,7 +68,7 @@ spec:
         volumeMounts:
         - mountPath: /mnt/cache
           name: cache-ssd
-      - image: index.docker.io/sourcegraph/jaeger-agent:insiders@sha256:01b0798f278b80b7b312caf53792a0207ca958fd88487e7ec6857b6b88694caf
+      - image: index.docker.io/sourcegraph/jaeger-agent:3.24.0@sha256:0d6c47cfa4087b6109224471a64d7f0202be4230666a16c1001db2b98dea5bd3
         name: jaeger-agent
         env:
           - name: POD_NAME

--- a/base/syntect-server/syntect-server.Deployment.yaml
+++ b/base/syntect-server/syntect-server.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - env:
-        image: index.docker.io/sourcegraph/syntax-highlighter:insiders@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
+        image: index.docker.io/sourcegraph/syntax-highlighter:3.24.0@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/configure/ssd/pod-tmp-gc.ClusterRoleBinding.yaml
+++ b/configure/ssd/pod-tmp-gc.ClusterRoleBinding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     category: rbac
-    deploy: pod-tmp-gc 
+    deploy: pod-tmp-gc
   name: pod-tmp-gc
 roleRef:
   apiGroup: ""
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: pod-tmp-gc
-  namespace: default
+  namespace: workiva


### PR DESCRIPTION
Currently the prometheus deployment cannot be scheduled b/c it is asking for more ephemeral storage than what is available on the nodes. Since few other deployments require ephemeral storage and prometheus isn't currently being used, remove the requested amount so that it can be scheduled.